### PR TITLE
Fixed defect with CSV unique function.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "deep-cuts",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "qs": "^6.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-cuts",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Useful utilities and rare b-sides.",
   "author": "Trevor Ewen",
   "license": "MIT",

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -50,7 +50,7 @@ const flattenDeep = (ar: any[]): any[] =>
     ? (ar || []).reduce((acc, v) => acc.concat(flattenDeep(v)), [])
     : ar;
 
-const unique = (ar: any[]): any[] => [...new Set(ar)];
+const unique = (ar: any[]): any[] => Array.from(new Set(ar));
 
 export function csvRowsToObjects(
   rows: any[][],


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Bug with set creation on the private unique method.


* **What is the current behavior?** (You can also link to an open issue here)
* Sets become members of the array.


* **What is the new behavior (if this is a feature change)?**
* Sets are converted to an array.

