### PR TITLE
CSV creation defect, zero values no longer turned into blank strings.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+#### What kind of change does this PR introduce? *(Bug fix, feature, docs update, ...)*
 
 
 
-* **What is the current behavior?** (You can also link to an open issue here)
+#### What is the current behavior? *(You can also link to an open issue here)*
 
 
 
-* **What is the new behavior (if this is a feature change)?**
+#### What is the new behavior? *(if this is a feature change)*
 
 
 
-* **Other information**:
+#### Other information:

--- a/src/__tests__/csv.test.ts
+++ b/src/__tests__/csv.test.ts
@@ -437,6 +437,29 @@ describe('csv', () => {
       ]);
     });
 
+    it('should play nice with 0 as a numeric value in the row', () => {
+      expect(
+        objectsToCsvRows([
+          {
+            Red: '1',
+            Green: 0,
+            Blue: 'Ronnie James',
+            Purple: 42,
+          },
+          {
+            Red: 0,
+            Green: 'Koolaid',
+            Blue: 'Peter Griffin',
+            Maroon: 88,
+          },
+        ])
+      ).toEqual([
+        ['Red', 'Green', 'Blue', 'Purple', 'Maroon'],
+        ['1', 0, 'Ronnie James', 42, ''],
+        [0, 'Koolaid', 'Peter Griffin', '', 88],
+      ]);
+    });
+
     it('should properly map dot properties out to rows', () => {
       expect(
         objectsToCsvRows([

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -193,7 +193,8 @@ export function objectsToCsvRows(
       );
       const rows = flattenedBase.map(obj =>
         header.map(key => {
-          const value = getValue(obj, key, obj[key]) || '';
+          const valueFromObject = getValue(obj, key, obj[key]);
+          const value = !isEmpty(valueFromObject) ? valueFromObject : '';
           if (Array.isArray(value)) {
             return value
               .map(item => {


### PR DESCRIPTION
#### What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
* Bug fix.


#### What is the current behavior?** (You can also link to an open issue here)
* Zeroes turned into blank strings in CSV creation.


#### What is the new behavior (if this is a feature change)?**
* Zeroes no longer turned into blank strings in CSV creation.
